### PR TITLE
Prune .swp files

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -63,6 +63,7 @@ var DefaultExtensions = []string{
 	".jst",
 	".coffee",
 	".tgz",
+        ".swp",
 }
 
 // Stats for a prune.


### PR DESCRIPTION
Vim may create these. They're just swap files.  I don't think anyone would ever want them in node_modules. 