### PR TITLE
Fix syntax errors

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -23,16 +23,16 @@ var DefaultFiles = []string{
 	".gitattributes",
 	".editorconfig",
 	".eslintrc",
-	".eslintrc.js"
+	".eslintrc.js",
 	".eslintignore",
-	".npmignore"
+	".npmignore",
 	".jshintrc",
 	".flowconfig",
 	".documentup.json",
 	".yarn-metadata.json",
 	".travis.yml",
 	"circle.yml",
-	".coveralls.yml"
+	".coveralls.yml",
 	"CHANGES",
 	"LICENSE.txt",
 	"LICENSE",
@@ -60,7 +60,7 @@ var DefaultDirectories = []string{
 	"examples",
 	"coverage",
 	".nyc_output",
-	".circleci"
+	".circleci",
 }
 
 // DefaultExtensions pruned.


### PR DESCRIPTION
A previous commit missed some commas, leading to a syntax error with go v1.9.2.

```
$ go build
# github.com/tj/node-prune
./prune.go:26:16: syntax error: unexpected newline, expecting comma or }
./prune.go:63:13: syntax error: unexpected newline, expecting comma or }
```

After this change, it builds without error.