### PR TITLE
Add missing comma on Default files declaration

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -39,7 +39,7 @@ var DefaultFiles = []string{
 	".htmllintrc",
 	"htmllint.js",
 	".lint",
-	".npmrc"
+	".npmrc",
 	".npmignore",
 	".jshintrc",
 	".flowconfig",


### PR DESCRIPTION
We encountered an error in your latest update.

You missed a `,` in the prune.go file which is causing the installation of your library to fail. This is the error:

```
/go/src/github.com/tj/node-prune/prune.go:42:10: syntax error: unexpected newline, expecting comma or }
```